### PR TITLE
Catch and warn draining errors on publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "command": {
     "publish": {
       "ignoreChanges": [

--- a/packages/core/__mocks__/nats.js
+++ b/packages/core/__mocks__/nats.js
@@ -19,6 +19,8 @@ class MockConnection extends EventEmitter {
       cb();
     });
 
+    this.close = jest.fn();
+
     this.request = jest.fn((name, payload, options, cb) => {
       cb(__testResponse);
     });

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@naty/core",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnatty/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "<Need description>",
   "license": "ISC",
   "main": "dist/index.js",

--- a/packages/gateway/package-lock.json
+++ b/packages/gateway/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@naty/gateway",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnatty/gateway",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "<Need description>",
   "license": "ISC",
   "main": "dist/index.js",
@@ -16,7 +16,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@gnatty/core": "^0.1.0",
+    "@gnatty/core": "^0.1.1",
     "config": "^3.2.6"
   },
   "publishConfig": {


### PR DESCRIPTION
Server.publish would throw and log an error if connections are draining. We now catch those errors
and warn the draining log but log all other errors

fix #12